### PR TITLE
widgets/wt_label.c: Skip fillup on negative w->w

### DIFF
--- a/widgets/wt_checkbox.c
+++ b/widgets/wt_checkbox.c
@@ -56,12 +56,15 @@ static void wt_checkbox_draw(struct stfl_widget *w, struct stfl_form *f, WINDOW 
 			stfl_widget_getkv_str(w, L"text_1", L"[X]") :
 			stfl_widget_getkv_str(w, L"text_0", L"[ ]");
 
-	wchar_t *fillup = malloc(sizeof(wchar_t)*(w->w + 1));
-	for (i=0;i < w->w;++i)
-		fillup[i] = L' ';
-	fillup[w->w] = L'\0';
-	mvwaddnwstr(win, w->y, w->x, fillup, wcswidth(fillup,wcslen(fillup)));
-	free(fillup);
+	if (w->w >= 0) {
+		wchar_t *fillup = calloc(w->w + 1, sizeof(wchar_t));
+		for (i=0;i < w->w;++i) {
+			fillup[i] = L' ';
+		}
+		fillup[w->w] = L'\0';
+		mvwaddnwstr(win, w->y, w->x, fillup, wcswidth(fillup,wcslen(fillup)));
+		free(fillup);
+	}
 
 	if (is_richtext)
 		stfl_print_richtext(w, win, w->y, w->x, text, w->w, style, 0);

--- a/widgets/wt_label.c
+++ b/widgets/wt_label.c
@@ -45,8 +45,8 @@ static void wt_label_draw(struct stfl_widget *w, struct stfl_form *f, WINDOW *wi
 
 	text = stfl_widget_getkv_str(w,L"text",L"");
 
-	if (1) {
-		wchar_t *fillup = malloc(sizeof(wchar_t)*(w->w + 1));
+	if (w->w >= 0) {
+		wchar_t *fillup = calloc(w->w + 1, sizeof(wchar_t));
 		for (i=0;i < w->w;++i) {
 			fillup[i] = L' ';
 		}

--- a/widgets/wt_list.c
+++ b/widgets/wt_list.c
@@ -195,8 +195,8 @@ static void wt_list_draw(struct stfl_widget *w, struct stfl_form *f, WINDOW *win
 
 		text = stfl_widget_getkv_str(c, L"text", L"");
 
-		if (1) {
-			wchar_t *fillup = malloc(sizeof(wchar_t)*(w->w + 1));
+		if (w->w >= 0) {
+			wchar_t *fillup = calloc(w->w + 1, sizeof(wchar_t));
 			for (j=0;j < w->w;++j) {
 				fillup[j] = ' ';
 			}


### PR DESCRIPTION
If w->w is negative malloc can fail and return NULL, which results in a segfault.

Also changed it to use calloc instead of malloc to avoid potential overflows.
